### PR TITLE
chore(ios): update spm from 7.0.0 to 8.0.0-beta

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["KeyboardPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0-beta")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Updated the `capacitor-swift-pm.git` reference in the `Package.swift` file to `8.0.0-beta`.