### PR TITLE
fix(android): Adjust WebView sizing during keyboard size changes

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -57,15 +57,18 @@ public class Keyboard {
         FrameLayout content = activity.getWindow().getDecorView().findViewById(android.R.id.content);
         rootView = content.getRootView();
 
-      ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
-        boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
+        ViewCompat.setOnApplyWindowInsetsListener(
+            rootView,
+            (v, insets) -> {
+                boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
 
-        if (showingKeyboard && resizeOnFullScreen) {
-          possiblyResizeChildOfContent(true);
-        }
+                if (showingKeyboard && resizeOnFullScreen) {
+                    possiblyResizeChildOfContent(true);
+                }
 
-        return insets;
-      });
+                return insets;
+            }
+        );
 
         ViewCompat.setWindowInsetsAnimationCallback(
             rootView,


### PR DESCRIPTION
This PR fixes a bug pointed out [here](https://github.com/ionic-team/capacitor/pull/8180#issuecomment-3512336606), where an already open keyboard does not effect the webview resizing if it changes its size.

Reproduction: https://github.com/luisbytes/capacitor-resize

We are also removing edge to edge handling code, as in Capacitor 8 it will be handled in a core plugin:
https://github.com/ionic-team/capacitor/pull/8236