### PR TITLE
fix(android): fix incorrect layout sizing when launching with keyboard open

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -60,8 +60,8 @@ public class Keyboard {
         ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
             boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
 
-            if (showingKeyboard && resizeOnFullScreen) {
-                possiblyResizeChildOfContent(true);
+            if (resizeOnFullScreen) {
+                possiblyResizeChildOfContent(showingKeyboard);
             }
 
             return insets;


### PR DESCRIPTION
## Description
Changed the condition inside Keyboard.java  setOnApplyWindowInsetsListener to call possiblyResizeChildOfContent(showingKeyboard) whenever resizeOnFullScreen is true, rather than only when the keyboard is actively showing.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
When an app is launched while the software keyboard is open (for example, when opening the app from the device's launcher search bar), the system briefly reports the keyboard as open, and then immediately dismisses it as the app takes focus.

Previously, the setOnApplyWindowInsetsListener conditionally fired possiblyResizeChildOfContent(true) only if the keyboard was showing. When the keyboard immediately closed, the listener fired again but completely ignored the false state, leaving the app's UI permanently shrunk/pushed up.

## Tests or Reproductions

1. Set resizeOnFullScreen to true
2. Open the Android app drawer / search bar so the software keyboard is visible
3. Tap the app icon to launch it

Before: The app loads, the keyboard hides, but the bottom portion of the screen remains pushed up
After: The app loads, the keyboard hides, and the layout correctly re-expands to claim the full screen height

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web