### PR TITLE
fix(android): null-check getRootWindowInsets() in onEnd to prevent NPE when view is detached

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -106,8 +106,11 @@ public class Keyboard {
                 @Override
                 public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
                     super.onEnd(animation);
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
+                    if (insets == null) {
+                        return;
+                    }
+                    boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
                     int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
                     DisplayMetrics dm = activity.getResources().getDisplayMetrics();
                     final float density = dm.density;


### PR DESCRIPTION
Description
Add a null-check on ViewCompat.getRootWindowInsets() in the onEnd method of WindowInsetsAnimationCompat.Callback to prevent a NullPointerException crash when the view is already detached from the window.

Change Type
 Fix
Rationale / Problems Fixed
ViewCompat.getRootWindowInsets(rootView) can return null when the root view is detached from the window (e.g. during activity tear-down or rapid navigation). The original code called .isVisible() directly on the result without any null-check, causing a fatal crash:
Fatal Exception: java.lang.NullPointerException
at com.capacitorjs.plugins.keyboard.Keyboard$1.onEnd(Keyboard.java:109)

Additionally, getRootWindowInsets() was being called twice unnecessarily — once for isVisible() and once for getInsets(). The fix consolidates both calls into a single assignment with an early-return guard.

Tests or Reproductions
The crash is reliably triggered by detaching the view while a keyboard animation is in progress (e.g. navigating away from a screen that has an open soft keyboard). After the fix, the onEnd callback returns early instead of crashing.

Screenshots / Media
N/A

Platforms Affected
 Android
Notes / Comments
This affects @capacitor/keyboard 8.0.1, which is the latest available version at time of writing. The fix is minimal and non-breaking: if insets is null, the keyboard event is simply not dispatched for that animation cycle.