### PR TITLE
fix(android): restore content height when keyboard hides via insets l…

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -60,8 +60,8 @@ public class Keyboard {
         ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
             boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
 
-            if (showingKeyboard && resizeOnFullScreen) {
-                possiblyResizeChildOfContent(true);
+            if (resizeOnFullScreen) {
+                possiblyResizeChildOfContent(showingKeyboard);
             }
 
             return insets;


### PR DESCRIPTION

The onApplyWindowInsetsListener only called possiblyResizeChildOfContent when the keyboard was showing, but never restored the content height when the keyboard was dismissed. This caused a ghost keyboard bug where returning to the app after using the keyboard in the notification pane left a black space where the keyboard was, because the content view height remained shrunk.

The fix passes the current keyboard visibility state to possiblyResizeChildOfContent so it resets the height to MATCH_PARENT when the keyboard is no longer visible. This handles cases where the keyboard is dismissed without a WindowInsetsAnimation (e.g. switching back to the app from the notification shade).

## Description
<!--- Describe your changes in detail -->

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [ ] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
