### PR TITLE
docs: Fix wording in keyboard configuration section

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -5,7 +5,7 @@ import type { PluginListenerHandle } from '@capacitor/core';
 declare module '@capacitor/cli' {
   export interface PluginsConfig {
     /**
-     * On iOS, the keyboard can be configured with the following options:
+     * The keyboard can be configured with the following options:
      */
     Keyboard?: {
       /**


### PR DESCRIPTION
like https://github.com/ionic-team/capacitor-keyboard/pull/54 but on the definitions.ts file