### PR TITLE
fix(android): reset WebView height when keyboard hides without animation

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -58,7 +58,9 @@ public class Keyboard {
         rootView = content.getRootView();
 
         ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
-            boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
+            WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(rootView);
+            if (rootInsets == null) return insets;
+            boolean showingKeyboard = rootInsets.isVisible(WindowInsetsCompat.Type.ime());
 
             if (resizeOnFullScreen) {
                 possiblyResizeChildOfContent(showingKeyboard);
@@ -85,8 +87,9 @@ public class Keyboard {
                     @NonNull WindowInsetsAnimationCompat animation,
                     @NonNull WindowInsetsAnimationCompat.BoundsCompat bounds
                 ) {
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
+                    if (insets == null) return super.onStart(animation, bounds);
+                    boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
                     int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
                     DisplayMetrics dm = activity.getResources().getDisplayMetrics();
                     final float density = dm.density;
@@ -106,8 +109,9 @@ public class Keyboard {
                 @Override
                 public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
                     super.onEnd(animation);
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
+                    if (insets == null) return;
+                    boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
                     int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
                     DisplayMetrics dm = activity.getResources().getDisplayMetrics();
                     final float density = dm.density;

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -60,8 +60,8 @@ public class Keyboard {
         ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
             boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
 
-            if (showingKeyboard && resizeOnFullScreen) {
-                possiblyResizeChildOfContent(true);
+            if (resizeOnFullScreen) {
+                possiblyResizeChildOfContent(showingKeyboard);
             }
 
             return insets;

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
@@ -26,13 +26,10 @@ public class KeyboardPlugin extends Plugin {
     @PluginMethod
     public void show(final PluginCall call) {
         execute(() ->
-            new Handler(Looper.getMainLooper()).postDelayed(
-                () -> {
-                    implementation.show();
-                    call.resolve();
-                },
-                350
-            )
+            new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                implementation.show();
+                call.resolve();
+            }, 350)
         );
     }
 


### PR DESCRIPTION
## Description

Two fixes for `Keyboard.java`:

**1. Reset WebView height when keyboard hides without animation** (commit 1)

The `setOnApplyWindowInsetsListener` only calls `possiblyResizeChildOfContent(true)` when the keyboard is showing, but never calls `possiblyResizeChildOfContent(false)` to reset. This means the WebView height reset relies entirely on `WindowInsetsAnimationCompat.Callback.onStart()`, which requires an animation to fire.

This fix passes the actual `showingKeyboard` state to `possiblyResizeChildOfContent()` so the insets listener handles both show and hide, matching the behavior already present in `onStart()`.

The change is safe because `possiblyResizeChildOfContent` is idempotent — it checks `usableHeightPrevious != usableHeightNow` before doing any work, so redundant calls during normal keyboard animations are no-ops.

**2. Guard against null WindowInsets during teardown** (commit 2)

`ViewCompat.getRootWindowInsets()` can return `null` when the root view is being detached (e.g. during activity destruction). All three call sites in the insets listener and animation callbacks now null-check before calling `isVisible()`, preventing a `NullPointerException`.

## Context

Fixes #30, fixes #51

When switching from an app with the keyboard open (e.g. Messages) back to a Capacitor app, the WebView remains resized as if the keyboard were open. The keyboard area appears greyed out even though no keyboard is visible.

**Root cause**: During app switching, Android dismisses the keyboard without an animation. The `setOnApplyWindowInsetsListener` fires and detects `showingKeyboard = true` (briefly, from the previous app's IME state), calling `possiblyResizeChildOfContent(true)` to shrink the WebView. The keyboard then closes instantly (no focused input in the destination app), but because there's no animation, `WindowInsetsAnimationCompat.Callback.onStart()` never fires, and `possiblyResizeChildOfContent(false)` is never called to reset the height.

This was introduced in #40, which added the `setOnApplyWindowInsetsListener` but only handled the show path.

Also related to #8 (same symptom reported on iOS with swipe gestures).

## Type of changes

- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected

- [x] Android
- [ ] iOS
- [ ] Web

## Tests

Tested on Android emulator (Pixel 9, API 35):

1. Open a Capacitor app with `resizeOnFullScreen: true`
2. Switch to Messages, type something (keyboard visible)
3. Switch back to the Capacitor app
4. **Before fix**: WebView stays shrunk, grey area at bottom where keyboard was
5. **After fix**: WebView correctly fills the full screen

Also verified normal keyboard behavior:
- Tap an input → keyboard opens → WebView resizes correctly
- Dismiss keyboard → WebView restores to full height
- Switch between inputs → resize adjusts properly

Repro app from #30: https://github.com/irshadshalu/capacitor-keyboard-bug-sample
