### PR TITLE
Fix/resize mode none capacitor 8 3

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -2,9 +2,7 @@ package com.capacitorjs.plugins.keyboard;
 
 import android.content.Context;
 import android.graphics.Rect;
-import android.os.Build;
 import android.util.DisplayMetrics;
-import android.util.TypedValue;
 import android.view.View;
 import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
@@ -12,7 +10,6 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsAnimationCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -59,13 +56,15 @@ public class Keyboard {
         rootView = content.getRootView();
 
         ViewCompat.setOnApplyWindowInsetsListener(content, (v, insets) -> {
-            boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
+            WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(rootView);
+            if (rootInsets == null) {
+                return insets;
+            }
+            boolean showingKeyboard = rootInsets.isVisible(WindowInsetsCompat.Type.ime());
 
             if (showingKeyboard && resizeOnFullScreen) {
                 possiblyResizeChildOfContent(true);
             }
-
-            v.onApplyWindowInsets(insets.toWindowInsets());
 
             return insets;
         });
@@ -88,8 +87,11 @@ public class Keyboard {
                     @NonNull WindowInsetsAnimationCompat animation,
                     @NonNull WindowInsetsAnimationCompat.BoundsCompat bounds
                 ) {
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
+                    if (insets == null) {
+                        return super.onStart(animation, bounds);
+                    }
+                    boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
                     int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
                     DisplayMetrics dm = activity.getResources().getDisplayMetrics();
                     final float density = dm.density;
@@ -98,10 +100,12 @@ public class Keyboard {
                         possiblyResizeChildOfContent(showingKeyboard);
                     }
 
-                    if (showingKeyboard) {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, Math.round(imeHeight / density));
-                    } else {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_HIDE, 0);
+                    if (keyboardEventListener != null) {
+                        if (showingKeyboard) {
+                            keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, Math.round(imeHeight / density));
+                        } else {
+                            keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_HIDE, 0);
+                        }
                     }
                     return super.onStart(animation, bounds);
                 }
@@ -109,16 +113,21 @@ public class Keyboard {
                 @Override
                 public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
                     super.onEnd(animation);
-                    boolean showingKeyboard = ViewCompat.getRootWindowInsets(rootView).isVisible(WindowInsetsCompat.Type.ime());
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
+                    if (insets == null) {
+                        return;
+                    }
+                    boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
                     int imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
                     DisplayMetrics dm = activity.getResources().getDisplayMetrics();
                     final float density = dm.density;
 
-                    if (showingKeyboard) {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_SHOW, Math.round(imeHeight / density));
-                    } else {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_HIDE, 0);
+                    if (keyboardEventListener != null) {
+                        if (showingKeyboard) {
+                            keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_SHOW, Math.round(imeHeight / density));
+                        } else {
+                            keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_HIDE, 0);
+                        }
                     }
                 }
             }

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -10,6 +10,7 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsAnimationCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -28,6 +29,7 @@ public class Keyboard {
     private int usableHeightPrevious;
     private FrameLayout.LayoutParams frameLayoutParams;
     private View mChildOfContent;
+    private boolean resizeEnabled;
 
     public void setKeyboardEventListener(@Nullable KeyboardEventListener keyboardEventListener) {
         this.keyboardEventListener = keyboardEventListener;
@@ -50,6 +52,7 @@ public class Keyboard {
     // We may want to deprecate this constructor in the future, but we are keeping it now to keep backward compatibility with cap 7
     public Keyboard(AppCompatActivity activity, boolean resizeOnFullScreen) {
         this.activity = activity;
+        this.resizeEnabled = resizeOnFullScreen;
 
         //http://stackoverflow.com/a/4737265/1091751 detect if keyboard is showing
         FrameLayout content = activity.getWindow().getDecorView().findViewById(android.R.id.content);
@@ -62,8 +65,17 @@ public class Keyboard {
             }
             boolean showingKeyboard = rootInsets.isVisible(WindowInsetsCompat.Type.ime());
 
-            if (showingKeyboard && resizeOnFullScreen) {
+            if (showingKeyboard && resizeEnabled) {
                 possiblyResizeChildOfContent(true);
+            }
+
+            // When resize is disabled, consume IME insets so that the WebView
+            // (and any other child) does not reflow its content when the keyboard
+            // appears (counteracts Capacitor bridge inset handling added in 8.3.0+).
+            if (!resizeEnabled && showingKeyboard) {
+                return new WindowInsetsCompat.Builder(insets)
+                    .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE)
+                    .build();
             }
 
             return insets;
@@ -96,7 +108,7 @@ public class Keyboard {
                     DisplayMetrics dm = activity.getResources().getDisplayMetrics();
                     final float density = dm.density;
 
-                    if (resizeOnFullScreen) {
+                    if (Keyboard.this.resizeEnabled) {
                         possiblyResizeChildOfContent(showingKeyboard);
                     }
 
@@ -135,6 +147,14 @@ public class Keyboard {
 
         mChildOfContent = content.getChildAt(0);
         frameLayoutParams = (FrameLayout.LayoutParams) mChildOfContent.getLayoutParams();
+    }
+
+    public void setResizeEnabled(boolean enabled) {
+        this.resizeEnabled = enabled;
+    }
+
+    public boolean isResizeEnabled() {
+        return this.resizeEnabled;
     }
 
     public void show() {

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -55,7 +55,7 @@ public class Keyboard {
         FrameLayout content = activity.getWindow().getDecorView().findViewById(android.R.id.content);
         rootView = content.getRootView();
 
-        ViewCompat.setOnApplyWindowInsetsListener(content, (v, insets) -> {
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, (v, insets) -> {
             WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(rootView);
             if (rootInsets == null) {
                 return insets;

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
@@ -12,11 +12,13 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 public class KeyboardPlugin extends Plugin {
 
     private Keyboard implementation;
+    private volatile String currentResizeMode = "none";
 
     @Override
     public void load() {
         execute(() -> {
             boolean resizeOnFullScreen = getConfig().getBoolean("resizeOnFullScreen", false);
+            currentResizeMode = resizeOnFullScreen ? "native" : "none";
             implementation = new Keyboard(getBridge(), resizeOnFullScreen);
 
             implementation.setKeyboardEventListener(this::onKeyboardEvent);
@@ -59,12 +61,20 @@ public class KeyboardPlugin extends Plugin {
 
     @PluginMethod
     public void setResizeMode(PluginCall call) {
-        call.unimplemented();
+        String mode = call.getString("mode", "none");
+        execute(() -> {
+            boolean resizeEnabled = !"none".equalsIgnoreCase(mode);
+            implementation.setResizeEnabled(resizeEnabled);
+            currentResizeMode = mode;
+            call.resolve();
+        });
     }
 
     @PluginMethod
     public void getResizeMode(PluginCall call) {
-        call.unimplemented();
+        JSObject result = new JSObject();
+        result.put("mode", currentResizeMode);
+        call.resolve(result);
     }
 
     @PluginMethod

--- a/ios/Sources/KeyboardPlugin/Keyboard.m
+++ b/ios/Sources/KeyboardPlugin/Keyboard.m
@@ -240,6 +240,20 @@ double stageManagerOffset;
       [self.webView setFrame:CGRectMake(wf.origin.x, wf.origin.y, f.size.width - wf.origin.x, f.size.height - wf.origin.y - self.paddingBottom)];
       break;
     }
+    case ResizeNone:
+    {
+      // Actively restore the webview to its full-screen frame to counteract any
+      // keyboard-induced resize that Capacitor's bridge may apply (8.3.0+).
+      [self.webView setFrame:CGRectMake(wf.origin.x, wf.origin.y, f.size.width - wf.origin.x, f.size.height - wf.origin.y)];
+      // Also reset additionalSafeAreaInsets.bottom in case the bridge raised it
+      // to push content above the keyboard.
+      UIEdgeInsets safeInsets = self.bridge.viewController.additionalSafeAreaInsets;
+      if (safeInsets.bottom != 0) {
+        safeInsets.bottom = 0;
+        self.bridge.viewController.additionalSafeAreaInsets = safeInsets;
+      }
+      break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
Description
Fix [setResizeMode("none")](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (and the resize: "none" plugin config) not preventing the WebView from being resized when the software keyboard appears, after upgrading to Capacitor 8.3.0.

Change Type
 Fix
Rationale / Problems Fixed
Capacitor 8.3.0 introduced bridge-level IME inset handling on both iOS and Android that resizes the WebView when the software keyboard is shown. This change bypasses the resize policy that this plugin is supposed to enforce, making [setResizeMode("none")](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (and resize: "none" in plugin config) completely ineffective after upgrading from 8.1.x.

iOS: _updateFrame had no case ResizeNone: branch, so the bridge was free to shrink the WebView frame and raise [additionalSafeAreaInsets.bottom](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) unchecked.

Android: [setResizeMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [getResizeMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) were always returning [call.unimplemented()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). Additionally, the resize policy was captured in the constructor as an effectively-final local variable ([resizeOnFullScreen](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)), making it impossible to change at runtime even if the methods had been implemented.

Tests or Reproductions
Create a Capacitor 8.3.0 app with this plugin configured as resize: "none" in capacitor.config.ts:
Focus any text input to trigger the software keyboard.
Before this fix: the WebView shrinks to push content above the keyboard.
After this fix: the WebView stays full-screen and the keyboard overlaps the content as expected.
Same reproduction applies when calling [Keyboard.setResizeMode({ mode: 'none' })](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) at runtime.

Platforms Affected
 Android
 iOS
Notes / Comments
iOS changes ([Keyboard.m](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)):

Added explicit case ResizeNone: in _updateFrame that restores the WebView to its full-screen frame and resets [additionalSafeAreaInsets.bottom](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to 0 if the bridge raised it.
Android changes (android/.../Keyboard.java):

Replaced the constructor-captured [resizeOnFullScreen](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) boolean with a mutable [resizeEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) field so the policy can be toggled at runtime via [setResizeEnabled(boolean)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
When [resizeEnabled](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is false and the keyboard is visible, IME [WindowInsetsCompat](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) are consumed before being dispatched to the WebView, counteracting the new bridge inset handling introduced in 8.3.0.
Android changes (android/.../KeyboardPlugin.java):

Implemented [setResizeMode()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [getResizeMode()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) plugin methods (previously [unimplemented()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
[currentResizeMode](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is initialised at [load()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) time from the [resizeOnFullScreen](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) config value.