### PR TITLE
chore: update dependencies for Capacitor 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .target(
             name: "KeyboardPlugin",
             dependencies: [
-                .product(name: "Capacitor", package: "capacitor-swift-pm")],
+                .product(name: "Capacitor", package: "capacitor-swift-pm")
+            ],
             path: "ios/Sources/KeyboardPlugin",
             publicHeadersPath: "include"),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,13 @@ let package = Package(
             targets: ["KeyboardPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "9.0.0-alpha.0")
     ],
     targets: [
         .target(
             name: "KeyboardPlugin",
             dependencies: [
-                .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")],
+                .product(name: "Capacitor", package: "capacitor-swift-pm")],
             path: "ios/Sources/KeyboardPlugin",
             publicHeadersPath: "include"),
         .testTarget(

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "publish:cocoapod": "pod trunk push ./CapacitorKeyboard.podspec --allow-warnings"
   },
   "devDependencies": {
-    "@capacitor/android": "^8.0.0",
-    "@capacitor/cli": "^8.0.0",
-    "@capacitor/core": "^8.0.0",
+    "@capacitor/android": "next",
+    "@capacitor/cli": "next",
+    "@capacitor/core": "next",
     "@capacitor/docgen": "^0.3.0",
-    "@capacitor/ios": "^8.0.0",
+    "@capacitor/ios": "next",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "^4.0.0",
     "@ionic/swiftlint-config": "^2.0.0",
@@ -71,7 +71,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=8.0.0"
+    "@capacitor/core": ">=9.0.0-alpha.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Prepares the `next` branch for Capacitor 9 work by aligning the dependency declarations:

- `Package.swift`: bump `capacitor-swift-pm` to its Capacitor 9 line (`9.0.0-alpha.0`) and drop the `Cordova` product.
- `package.json`: switch `@capacitor/{android,core,ios, cli}` devDependencies to `next` and bump `@capacitor/core` peerDependency to `>=9.0.0-alpha.0`.

Refs: [RMET-5266](https://outsystemsrd.atlassian.net/browse/RMET-5266) 

## Change Type
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
The keyboard `next` branch is currently aligned with Capacitor 8 dependencies and is not ready for Cap 9 work. 



[RMET-5263]: https://outsystemsrd.atlassian.net/browse/RMET-5263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RMET-5266]: https://outsystemsrd.atlassian.net/browse/RMET-5266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ