### PR TITLE
refactor(android): remove deprecated HIDE_NOT_ALWAYS flag

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -143,7 +143,7 @@ public class Keyboard {
         if (v == null) {
             return false;
         } else {
-            inputManager.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+            inputManager.hideSoftInputFromWindow(v.getWindowToken(), 0);
             return true;
         }
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace the deprecated `InputMethodManager.HIDE_NOT_ALWAYS` flag with `0` in `Keyboard.hide()`

Ref: [RMET-5240](https://outsystemsrd.atlassian.net/browse/RMET-5240)


## Change Type
- [ ] Fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->
`InputMethodManager.HIDE_NOT_ALWAYS` has been deprecated by Android. `Keyboard.hide()` is called when the JS layer explicitly requests the keyboard to be dismissed, so passing `0` (no flags) preserves the intended behavior without relying on the deprecated constant.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->


[RMET-5240]: https://outsystemsrd.atlassian.net/browse/RMET-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ