### PR TITLE
feat(android): add LAST_KNOWN eventMode config option

### DIFF
--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -122,7 +122,7 @@ public class Keyboard {
                 justEndedAnimation = false;
             }
 
-            logDebug("onApplyWindowInsets - showingKeyboard=" + showingKeyboard, insets, imeHeight);
+
 
             if (showingKeyboard && resizeOnFullScreen) {
                 possiblyResizeChildOfContent(true);
@@ -198,7 +198,7 @@ public class Keyboard {
                         keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_HIDE, 0);
                     }
 
-                    logDebug("onStart - showingKeyboard=" + showingKeyboard, insets, imeHeight);
+
 
                     return super.onStart(animation, bounds);
                 }
@@ -206,6 +206,8 @@ public class Keyboard {
                 @Override
                 public void onEnd(@NonNull WindowInsetsAnimationCompat animation) {
                     super.onEnd(animation);
+                    isAnimating = false;
+
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
                     if (insets == null) return;
                     boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
@@ -214,10 +216,38 @@ public class Keyboard {
                     final float density = dm.density;
 
                     if (showingKeyboard) {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_SHOW, Math.round(imeHeight / density));
+                        justEndedAnimation = true;
+
+                        int currentImeHeight = Math.round(imeHeight / density);
+                        int emitHeight = currentImeHeight;
+                        if (eventMode == EventMode.LAST_KNOWN && knownKeyboardHeight > 0 && currentImeHeight > knownKeyboardHeight) {
+                            emitHeight = knownKeyboardHeight;
+                        }
+
+                        if (emitHeight != lastImeHeight) {
+                            lastImeHeight = emitHeight;
+                            if (keyboardEventListener != null) {
+                                keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_SHOW, lastImeHeight);
+                            }
+                        }
+
+                        // Update the known keyboard height to the final settled height after animation.
+                        // We ONLY allow it to shrink here to prevent spurious tall frames (like during rapid aborts) from corrupting the ceiling.
+                        // If the keyboard genuinely grew, the subsequent onApplyWindowInsets layout pass will catch it via justEndedAnimation=true.
+                        if (eventMode == EventMode.LAST_KNOWN) {
+                            if (knownKeyboardHeight == 0 || currentImeHeight <= knownKeyboardHeight) {
+                                knownKeyboardHeight = currentImeHeight;
+                            }
+                        }
                     } else {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_HIDE, 0);
+                        justEndedAnimation = false;
+                        lastImeHeight = 0;
+                        if (keyboardEventListener != null) {
+                            keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_HIDE, 0);
+                        }
                     }
+
+
                 }
             }
         );

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/Keyboard.java
@@ -31,6 +31,27 @@ public class Keyboard {
     private int usableHeightPrevious;
     private FrameLayout.LayoutParams frameLayoutParams;
     private View mChildOfContent;
+    private int lastImeHeight = 0;
+
+    public enum EventMode {
+        DEFAULT,
+        LAST_KNOWN
+    }
+
+    private boolean isAnimating = false;
+    private boolean justEndedAnimation = false;
+    private int knownKeyboardHeight = 0;
+    private EventMode eventMode = EventMode.DEFAULT;
+
+    public void setEventMode(String modeStr) {
+        if (modeStr != null) {
+            try {
+                this.eventMode = EventMode.valueOf(modeStr.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                this.eventMode = EventMode.DEFAULT;
+            }
+        }
+    }
 
     public void setKeyboardEventListener(@Nullable KeyboardEventListener keyboardEventListener) {
         this.keyboardEventListener = keyboardEventListener;
@@ -63,25 +84,82 @@ public class Keyboard {
             if (rootInsets == null) return insets;
 
             boolean showingKeyboard = rootInsets.isVisible(WindowInsetsCompat.Type.ime());
+            int imeHeight = rootInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            DisplayMetrics dm = activity.getResources().getDisplayMetrics();
+            final float density = dm.density;
 
-            if (resizeOnFullScreen) {
-                possiblyResizeChildOfContent(showingKeyboard);
+            if (showingKeyboard) {
+                int currentImeHeight = Math.round(imeHeight / density);
+                if (!isAnimating) {
+                    int emitHeight = currentImeHeight;
+                    if (eventMode == EventMode.LAST_KNOWN) {
+                        if (knownKeyboardHeight == 0) {
+                            knownKeyboardHeight = currentImeHeight;
+                        } else if (justEndedAnimation) {
+                            knownKeyboardHeight = currentImeHeight;
+                        } else if (currentImeHeight > knownKeyboardHeight) {
+                            emitHeight = knownKeyboardHeight;
+                        } else if (currentImeHeight < knownKeyboardHeight) {
+                            knownKeyboardHeight = currentImeHeight;
+                        }
+                    } else {
+                        knownKeyboardHeight = currentImeHeight;
+                    }
+
+                    if (emitHeight != lastImeHeight && keyboardEventListener != null) {
+                        lastImeHeight = emitHeight;
+                        keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, emitHeight);
+                        keyboardEventListener.onKeyboardEvent(EVENT_KB_DID_SHOW, emitHeight);
+                    }
+                    justEndedAnimation = false;
+                } else if (eventMode == EventMode.LAST_KNOWN) {
+                    if (knownKeyboardHeight == 0) {
+                        knownKeyboardHeight = currentImeHeight;
+                    }
+                }
+            } else {
+                lastImeHeight = 0;
+                justEndedAnimation = false;
             }
 
-            v.onApplyWindowInsets(insets.toWindowInsets());
+            logDebug("onApplyWindowInsets - showingKeyboard=" + showingKeyboard, insets, imeHeight);
 
-            return insets;
+            if (showingKeyboard && resizeOnFullScreen) {
+                possiblyResizeChildOfContent(true);
+            } else if (!showingKeyboard && resizeOnFullScreen) {
+                possiblyResizeChildOfContent(false);
+            }
+
+            WindowInsetsCompat insetsToApply = insets;
+            if (!resizeOnFullScreen) {
+                insetsToApply = new WindowInsetsCompat.Builder(insets)
+                    .setInsets(WindowInsetsCompat.Type.ime(), androidx.core.graphics.Insets.NONE)
+                    .build();
+            }
+
+            return ViewCompat.onApplyWindowInsets(v, insetsToApply);
         });
 
         ViewCompat.setWindowInsetsAnimationCallback(
             rootView,
             new WindowInsetsAnimationCompat.Callback(WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_STOP) {
+                @Override
+                public void onPrepare(@NonNull WindowInsetsAnimationCompat animation) {
+                    isAnimating = true;
+                    super.onPrepare(animation);
+                }
+
                 @NonNull
                 @Override
                 public WindowInsetsCompat onProgress(
                     @NonNull WindowInsetsCompat insets,
                     @NonNull List<WindowInsetsAnimationCompat> runningAnimations
                 ) {
+                    if (!resizeOnFullScreen) {
+                        return new WindowInsetsCompat.Builder(insets)
+                            .setInsets(WindowInsetsCompat.Type.ime(), androidx.core.graphics.Insets.NONE)
+                            .build();
+                    }
                     return insets;
                 }
 
@@ -91,6 +169,8 @@ public class Keyboard {
                     @NonNull WindowInsetsAnimationCompat animation,
                     @NonNull WindowInsetsAnimationCompat.BoundsCompat bounds
                 ) {
+                    isAnimating = true;
+                    justEndedAnimation = false;
                     WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(rootView);
                     if (insets == null) return super.onStart(animation, bounds);
                     boolean showingKeyboard = insets.isVisible(WindowInsetsCompat.Type.ime());
@@ -103,10 +183,23 @@ public class Keyboard {
                     }
 
                     if (showingKeyboard) {
-                        keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, Math.round(imeHeight / density));
+                        int currentImeHeight = Math.round(imeHeight / density);
+                        int emitHeight = currentImeHeight;
+                        if (eventMode == EventMode.LAST_KNOWN && knownKeyboardHeight > 0 && currentImeHeight > knownKeyboardHeight) {
+                            emitHeight = knownKeyboardHeight;
+                        }
+
+                        if (emitHeight != lastImeHeight) {
+                            lastImeHeight = emitHeight;
+                            keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_SHOW, lastImeHeight);
+                        }
                     } else {
+                        lastImeHeight = 0;
                         keyboardEventListener.onKeyboardEvent(EVENT_KB_WILL_HIDE, 0);
                     }
+
+                    logDebug("onStart - showingKeyboard=" + showingKeyboard, insets, imeHeight);
+
                     return super.onStart(animation, bounds);
                 }
 

--- a/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
+++ b/android/src/main/java/com/capacitorjs/plugins/keyboard/KeyboardPlugin.java
@@ -17,7 +17,9 @@ public class KeyboardPlugin extends Plugin {
     public void load() {
         execute(() -> {
             boolean resizeOnFullScreen = getConfig().getBoolean("resizeOnFullScreen", false);
+            String eventMode = getConfig().getString("eventMode", "DEFAULT");
             implementation = new Keyboard(getBridge(), resizeOnFullScreen);
+            implementation.setEventMode(eventMode);
 
             implementation.setKeyboardEventListener(this::onKeyboardEvent);
         });

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -43,6 +43,16 @@ declare module '@capacitor/cli' {
       resizeOnFullScreen?: boolean;
 
       /**
+       * The event mode determines how the plugin emits lifecycle events during keyboard animations.
+       *
+       * Only available for Android
+       *
+       * @since 8.0.5
+       * @example "LAST_KNOWN"
+       */
+      eventMode?: KeyboardEventMode;
+
+      /**
        * Controls how the keyboard backdrop color (the area visible behind the
        * keyboard) is set every time the keyboard is about to show.
        *
@@ -63,6 +73,8 @@ declare module '@capacitor/cli' {
     };
   }
 }
+
+export type KeyboardEventMode = 'DEFAULT' | 'LAST_KNOWN';
 
 export interface KeyboardInfo {
   /**


### PR DESCRIPTION
## Bug Report / Issue

Closes https://github.com/ionic-team/capacitor-plugins/issues/2587

## Description

On Android, the `@capacitor/keyboard` plugin can report inconsistent or incorrect keyboard heights (sometimes smaller than the actual keyboard, or `0`) during keyboard animations or when `WindowInsets` are applied. The events `keyboardWillShow` and `keyboardDidShow` may fire with intermediate sizes instead of the final settled keyboard height, causing UI jumps or layout issues, particularly noticeable on newer Android versions (14/15) with edge-to-edge configurations.

This is a root cause of the common "Grey bar above keyboard" issue reported in many other issues (such as ionic-team/capacitor#8525, ionic-team/capacitor#8575, ionic-team/capacitor#8329, and ionic-team/capacitor-plugins#2205).

This PR introduces an `eventMode: "LAST_KNOWN"` configuration option for Android to smooth out the keyboard animation. 

### What it does:
1. **Tracks the Highest Known Height**: Tracks the `knownKeyboardHeight` to avoid emitting intermediate sizes during the `WindowInsetsAnimationCompat` lifecycle (`onPrepare`, `onProgress`, `onStart`, `onEnd`).
2. **Smooths Event Emission**: Only emits `WILL_SHOW` and `DID_SHOW` if the height actually changes, falling back to the `LAST_KNOWN` height instead of transient smaller heights during animation.

This change is backward compatible as the default `eventMode` remains `"DEFAULT"`.
